### PR TITLE
Make add route work for Linux

### DIFF
--- a/scripts/deploy-to-bosh-lite
+++ b/scripts/deploy-to-bosh-lite
@@ -65,10 +65,17 @@ upload_local_release() {
 }
 
 main() {
-    sudo route add -net 10.244.0.0/16 192.168.50.6
-
     create_bosh_env
     set_bosh_env
+
+    if [ `uname` == "Darwin" ]; then
+        sudo route add -net $ips $gw
+    elif [ `uname` == "Linux" ]; then
+        sudo route add -net $ips gw $gw
+    else
+        echo "ERROR adding route"
+        exit 1
+    fi
 
     if [ "$upload_stemcell" == true ]; then
       upload_bosh_stemcell
@@ -81,6 +88,8 @@ main() {
     deploy_cf
 }
 
+ips="10.244.0.0/16"
+gw="192.168.50.6"
 upload_stemcell=true
 
 main


### PR DESCRIPTION
Moved the route adding down in the execution order as trying to add a route before the virtualbox network was setup would result in an error.