### PR TITLE
Add netmon to list of components to remove

### DIFF
--- a/docs/3rd-party.md
+++ b/docs/3rd-party.md
@@ -47,11 +47,13 @@ Operators may wish to override the MTU setting. In this case they will set the B
 
 ## To author a BOSH release with your plugin
 0. Remove the following BOSH jobs:
+  - `netmon`
   - `silk-cni`
   - `silk-daemon`
   - `silk-controller`
   - `vxlan-policy-agent`
 0. Remove the following BOSH packages:
+  - `netmon`
   - `silk-cni`
   - `silk-daemon`
   - `silk-controller`


### PR DESCRIPTION
Netmon is configured for Silk and is not necessary for 3rd party CNI integrations.